### PR TITLE
Add Windows build workflow

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,0 +1,54 @@
+name: Build DICOM Viewer (Windows)
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build-windows:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Install dependencies via Chocolatey
+        shell: powershell
+        run: |
+          choco install -y qt6-base-dev vtklib dcmtk
+          refreshenv
+
+      - name: Configure MSVC environment
+        shell: cmd
+        run: |
+          call "%VSINSTALLDIR%\VC\Auxiliary\Build\vcvars64.bat"
+
+      - name: Configure project with CMake
+        shell: cmd
+        run: |
+          mkdir build
+          cd build
+          cmake .. -G "Visual Studio 17 2022" -A x64 ^
+            -DQt6_DIR="%ChocolateyInstall%\lib\qt6-base-dev\tools\qt\lib\cmake\Qt6" ^
+            -DVTK_DIR="%ChocolateyInstall%\lib\vtklib\lib\cmake\vtk-*" ^
+            -DDCMTK_DIR="%ChocolateyInstall%\lib\dcmtk\lib\cmake\dcmtk"
+
+      - name: Build in Release mode
+        shell: cmd
+        run: |
+          cd build
+          cmake --build . --config Release -- /m
+
+      - name: Run unit tests
+        shell: cmd
+        run: |
+          cd build
+          ctest --output-on-failure --config Release
+
+      - name: Upload build logs
+        uses: actions/upload-artifact@v3
+        with:
+          name: build-log
+          path: build/**/CMake*.log


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow for building on Windows

## Testing
- `cmake -S . -B build` *(fails: could not find Qt6)*
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_684dfec7fcb483279b1cb66106232034